### PR TITLE
feat(feeds): prune to open-licence sources & document compliance

### DIFF
--- a/Config.toml
+++ b/Config.toml
@@ -1,125 +1,74 @@
-# ────────────────────────────────────────────────────────────────────
+# ----------------------------------------------------------------------
 # Global settings
-# ────────────────────────────────────────────────────────────────────
+# ----------------------------------------------------------------------
 database_url    = "postgres://user:pass@db:5432/osint?sslmode=disable"
-ingest_interval = "1h"                     # human-readable (parsed by humantime_serde)
+ingest_interval = "1h"                     # human‑readable (parsed by humantime_serde)
 server_bind     = "0.0.0.0:9100"           # metrics & health HTTP endpoint
 
-# ───────────────────────────────────────────────────────────────────────────────
-# Feed sources
-# ───────────────────────────────────────────────────────────────────────────────
+# ----------------------------------------------------------------------
+# Feed sources – *public‑demo safe list*
+#   These are the only feeds whose licences permit public redistribution.
+# ----------------------------------------------------------------------
 [[feeds]]
-name      = "CISA Cybersecurity Alerts (US-CERT)"
+name      = "CISA Cybersecurity Alerts"
 url       = "https://us-cert.cisa.gov/ncas/alerts.xml"
 feed_type = "official"
+licence   = "Public Domain (US Government)"
 tags      = ["threat-alerts", "vulnerabilities"]
 
 [[feeds]]
 name      = "CISA Vulnerability Advisories"
 url       = "https://www.cisa.gov/cybersecurity-advisories/all.xml"
 feed_type = "official"
+licence   = "Public Domain (US Government)"
 tags      = ["vulnerabilities", "patches"]
 
 [[feeds]]
 name      = "UK NCSC Updates"
 url       = "https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml"
 feed_type = "official"
+licence   = "Open Government Licence v3.0"
 tags      = ["advisories", "guidance"]
 
 [[feeds]]
 name      = "SANS Internet Storm Center Diaries"
 url       = "https://isc.sans.edu/rssfeed_full.xml"
 feed_type = "community"
+licence   = "Creative Commons BY-NC-SA 3.0 US"
 tags      = ["analysis", "daily-threat"]
 
 [[feeds]]
-name      = "Krebs on Security"
-url       = "https://krebsonsecurity.com/feed/"
-feed_type = "independent"
-tags      = ["investigations", "breaches"]
-
-
-[[feeds]]
-name      = "BleepingComputer"
-url       = "https://www.bleepingcomputer.com/feed/"
-feed_type = "independent"
-tags      = ["malware", "vulnerabilities"]
-
-[[feeds]]
-name      = "Dark Reading"
-url       = "https://www.darkreading.com/rss.xml"
-feed_type = "independent"
-tags      = ["industry-news", "analysis"]
-
-[[feeds]]
-name      = "Threatpost"
-url       = "https://threatpost.com/feed/"
-feed_type = "independent"
-tags      = ["vulnerabilities", "policy"]
-
-[[feeds]]
-name      = "The Hacker News"
-url       = "https://feeds.feedburner.com/TheHackersNews"
-feed_type = "independent"
-tags      = ["general-security", "updates"]
-
-[[feeds]]
-name      = "Schneier on Security"
-url       = "https://www.schneier.com/blog/atom.xml"
-feed_type = "independent"
-tags      = ["insights", "policy"]
-
-[[feeds]]
-name      = "Malwarebytes Labs"
-url       = "https://blog.malwarebytes.com/feed/"
-feed_type = "independent"
-tags      = ["malware-research", "threat-trends"]
-
-[[feeds]]
-name      = "Cisco Talos Intelligence Blog"
-url       = "https://feeds.feedburner.com/feedburner/Talos"
-feed_type = "independent"
-tags      = ["threat-intel", "IOCs"]
-
-[[feeds]]
-name      = "Securelist (Kaspersky GReAT)"
-url       = "https://securelist.com/feed/"
-feed_type = "independent"
-tags      = ["APTs", "reverse-engineering"]
-
-[[feeds]]
-name      = "Exploit-DB Latest Exploits"
-url       = "https://www.exploit-db.com/rss.xml"
-feed_type = "open-source"
-tags      = ["exploit-code", "PoC"]
-
-[[feeds]]
-name      = "CERT/CC Vulnerability Notes"
-url       = "https://www.kb.cert.org/vulfeed/"
-feed_type = "official"
-tags      = ["vulnerabilities", "multi-vendor"]
-
-[[feeds]]
-name      = "Microsoft Security Response Center (MSRC)"
-url       = "https://msrc-blog.microsoft.com/feed/"
-feed_type = "official"
-tags      = ["patches", "product-security"]
-
-[[feeds]]
-name      = "CERT-EU Security Advisories"
+name      = "CERT‑EU Security Advisories"
 url       = "https://cert.europa.eu/publications/threat-intelligence-rss"
 feed_type = "official"
+licence   = "Creative Commons BY 4.0"
 tags      = ["EU-advisories", "vulnerabilities"]
 
-[[feeds]]
-name      = "Reddit /r/netsec feed"
-url       = "https://www.reddit.com/r/netsec/.rss"
-feed_type = "Open Source (Community)"
-tags      = ["Reddit", "netsec"]
-
-
-[[feeds]]
-name      = "Palo Alto Networks Security Advisories"
-url       = "https://security.paloaltonetworks.com/rss.xml"
-feed_type = "Vendor"
-tags      = ["Palo Alto Networks", "Security Avisories"]
+# ----------------------------------------------------------------------
+# Optional – additional open‑licence feeds (commented out)
+# Uncomment only after verifying the licence remains permissive.
+#
+# [[feeds]]
+# name      = "CISA Known Exploited Vulnerabilities (KEV)"
+# url       = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.xml"
+# feed_type = "official"
+# licence   = "Public Domain (US Government)"
+# tags      = ["kev", "exploited-in-the-wild"]
+#
+# [[feeds]]
+# name      = "Australian ACSC Alerts"
+# url       = "https://www.cyber.gov.au/alerts/rss.xml"
+# feed_type = "official"
+# licence   = "Creative Commons BY 4.0 AU"
+# tags      = ["advisories", "au"]
+# ----------------------------------------------------------------------
+# ----------------------------------------------------------------------
+# Licence‑compliance notes (informational)
+# ----------------------------------------------------------------------
+# • All feeds above are either public‑domain or published under a permissive
+#   Creative Commons / OGL licence that allows redistribution *with attribution*.
+# • The ingest pipeline must store only the original headline and a ≤100‑character
+#   AI‑generated summary in public caches.
+# • Any new feed added to this file must be reviewed for licence compatibility
+#   before deploying to the public demo.
+# ----------------------------------------------------------------------

--- a/cybersecurity_feeds.md
+++ b/cybersecurity_feeds.md
@@ -1,132 +1,81 @@
-# Top 20 Cybersecurity RSS/Atom Feeds for OSINT Ingestion MVP
+# TigerBlue OSINT Dashboard – **Licence-Compliant Feed List**
 
-The following matrix highlights 20 top free cybersecurity feeds covering threat intelligence, breaches, vulnerabilities, malware analysis, and general cyber news. These feeds include official CERT advisories, independent researchers, news sites, and community sources – all widely used in the cyber security community. Each feed is publicly available (free) and suitable for an OSINT aggregator.
+This documents the _public-demo_ feed set for TigerBlue.app after applying **Option B: “open-licence-only”**.  Every feed below is either U.S.-government public-domain, released under the UK Open Government Licence (OGL v3.0) or published under a permissive Creative Commons licence.  That means you can legally display _headline + short AI summary + link-back_ in a public dashboard with only minimal attribution.
 
+> **Important:** If you enable any additional feeds you _must_ verify the licence terms yourself before deploying them to the public instance.
 
-| Feed Name                                      | RSS/Atom Link                                                        | Focus Area(s)                                            | Type                         | Free/Paid | Short Summary of Coverage                                                                                                                                       |
-|-----------------------------------------------|----------------------------------------------------------------------|----------------------------------------------------------|------------------------------|-----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CISA Cybersecurity Alerts (US-CERT)           | https://us-cert.cisa.gov/ncas/alerts.xml                             | Threat alerts, current security issues                   | Official (Government)        | Free      | High-priority alerts from the US Cybersecurity & Infrastructure Security Agency. Provides timely info on current security issues, major threats, vulnerabilities and exploits. Useful for staying updated on active cyber incidents. |
-| CISA Vulnerability Advisories                 | https://www.cisa.gov/cybersecurity-advisories/all.xml                | Vulnerability disclosures, patches (incl. ICS)           | Official (Government)        | Free      | Official CISA advisories on newly discovered vulnerabilities. Details on affected systems, severity, and mitigation. Helps track critical patches and exploits as they are disclosed.                                                  |
-| UK NCSC Updates                               | https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml           | National cyber security news & advisories                | Official (Government)        | Free      | Updates from the UK’s National Cyber Security Centre. Includes news releases, threat guidance, and advisories, offering insight into UK government cyber defence initiatives and warnings. Useful for UK/EU-focused threat context. |
-| SANS Internet Storm Center (ISC) Diaries      | https://isc.sans.edu/rssfeed_full.xml                                | Daily threat analysis, emerging attack trends            | Independent (Community)      | Free      | Community volunteer handlers post daily diaries highlighting new threats and attack trends. Provides expert analysis of malware, exploits, and security incidents worldwide. Renowned as a crowdsourced early-warning system.         |
-| Krebs on Security (Brian Krebs)               | https://krebsonsecurity.com/feed/                                    | Cybercrime investigations, data breaches                 | Independent                  | Free      | Brian Krebs’s blog featuring investigative reporting on major data breaches, cybercrimes, and hacking incidents. Known for breaking stories on cybercrime gangs and breaches, with in-depth analysis and interviews.                 |
-| DataBreaches.net                              | https://databreaches.net/feed/                                       | Data breach incidents, leaks                             | Independent                  | Free      | Blog dedicated to data breach news across industries. Combines news aggregation with original investigative reporting and opinion on breach incidents. Tracks disclosed leaks, ransomware victim updates, and breach legislation news. |
-| BleepingComputer                              | https://www.bleepingcomputer.com/feed/                               | Cybersecurity news, malware, tech support threats        | Independent                  | Free      | A widely-followed security news site covering malware outbreaks, software vulnerabilities, data breaches, and technology news. Articles provide practical details and removal guidance for threats.                                |
-| Dark Reading                                  | https://www.darkreading.com/rss.xml                                  | Information security news, industry analysis             | Independent                  | Free      | Trusted online cybersecurity news outlet. Provides a broad range of infosec news, vulnerability reports, and expert analysis. Covers enterprise security trends, breaches, and research findings in depth.                           |
-| Threatpost                                    | https://threatpost.com/feed/                                         | Security news, threats & vulnerabilities                  | Independent                  | Free      | Independent IT security news site delivering daily stories on vulnerabilities, exploits, malware campaigns, and cybersecurity policy. Known for timely reporting with expert commentary.                                        |
-| The Hacker News                               | https://feeds.feedburner.com/TheHackersNews                          | General hacking & cyber news, malware, breaches          | Independent                  | Free      | Popular cybersecurity news source covering hacking incidents, data breaches, vulnerability alerts, and malware research. Updated frequently with brief, accessible reports on emerging threats.                                     |
-| Schneier on Security (Bruce Schneier)         | https://www.schneier.com/blog/atom.xml                               | Security insights, cryptography, policy                  | Independent                  | Free      | Bruce Schneier’s influential blog featuring commentary on security topics, cryptography, and privacy. Offers high-level insights and analysis from a renowned security technologist.                                           |
-| Graham Cluley Security                        | https://www.grahamcluley.com/feed/                                   | Security news, malware, privacy                          | Independent                  | Free      | Security blog by veteran UK antivirus researcher Graham Cluley. Covers the latest malware, hacking, and privacy news with a touch of opinion and humour. Provides easy-to-understand threat explanations and advice.            |
-| Malwarebytes Labs                             | https://blog.malwarebytes.com/feed/                                  | Malware analysis, threat research                        | Independent                  | Free      | Research blog by Malwarebytes. Publishes technical analyses of malware, ransomware, and phishing campaigns, as well as threat trend reports. Focuses on how threats work and how to remediate them.                                |
-| Cisco Talos Intelligence Blog                 | https://feeds.feedburner.com/feedburner/Talos                        | Threat intelligence research, malware campaigns          | Independent                  | Free      | Threat research updates from Cisco Talos. Provides deep dives into malware campaigns, new exploits, threat actor TTPs, and significant vulnerabilities, often including IOCs and defensive guidance.                                |
-| Securelist (Kaspersky GReAT)                  | https://securelist.com/feed/                                         | APT reports, malware research, threat intelligence       | Independent                  | Free      | Kaspersky Lab’s threat research blog covering APTs, malware evolution, and cyber-espionage campaigns. Offers technical reports on actor activity, malware reverse-engineering, and global threat statistics.                       |
-| Exploit-DB Latest Exploits                    | https://www.exploit-db.com/rss.xml                                   | Exploit code releases, PoC vulnerabilities               | Open Source                  | Free      | RSS feed of the Exploit Database. Lists newly submitted exploits and shellcode for known vulnerabilities. Ideal for tracking availability of exploit code for recent CVEs.                                                          |
-| CERT/CC Vulnerability Notes                   | https://www.kb.cert.org/vulfeed/                                     | Vulnerability advisories (multi-vendor)                  | Official (CERT)              | Free      | Feed of Vulnerability Notes from CERT/CC. Each note details a software vulnerability, affected products, impact, and remediation. Authoritative source of multi-vendor disclosures.                                             |
-| Reddit r/netsec                               | https://www.reddit.com/r/netsec/.rss                                 | Community-curated security news & discussion             | Open Source (Community)      | Free      | Reddit /r/netsec feed aggregating user-submitted cybersecurity news, blog posts, and discussion threads. Covers a wide range of security topics vetted by infosec enthusiasts.                                                     |
-| Microsoft Security Response Center (MSRC)     | https://msrc-blog.microsoft.com/feed/                                | Patch announcements, product security updates            | Official (Vendor)            | Free      | Official Microsoft Security Response Center blog feed. Details Microsoft product vulnerabilities, patch Tuesday releases, and security guidance. Essential for Windows and Azure ecosystem security.                            |
-| CERT-EU Security Advisories                   | https://cert.europa.eu/cert/Data/newsletter/reviewlatest-SecurityBulletins.xml | Security advisories, EU-focused vulnerabilities | Official (Government)        | Free      | Security bulletins from CERT-EU for EU institutions. Covers newly disclosed vulnerabilities, affected software, and recommended actions, offering a European perspective on major security updates.                          |
+---
 
+## 📜 Core public feeds
 
-*Note*: All above feeds are free to access and provide publicly available information. RSS/Atom links can be added directly to your feed reader or OSINT platform. Focus areas indicate the primary content, though many feeds cover multiple aspects of cybersecurity.
+| # | Feed Name | RSS/Atom Link | Focus Area(s) | Licence | Short Coverage Summary |
+|---|-----------|---------------|---------------|---------|------------------------|
+| 1 | **CISA Cybersecurity Alerts** | <https://us-cert.cisa.gov/ncas/alerts.xml> | Threat alerts | Public Domain (US-Gov) | High-priority alerts on active threats and exploited vulnerabilities from the US Cybersecurity & Infrastructure Security Agency. |
+| 2 | **CISA Vulnerability Advisories** | <https://www.cisa.gov/cybersecurity-advisories/all.xml> | Vulnerability disclosures, patches | Public Domain (US-Gov) | Authoritative advisories covering newly disclosed CVEs—including ICS/OT notices—with mitigation guidance and severity ratings. |
+| 3 | **UK NCSC Updates** | <https://www.ncsc.gov.uk/api/1/services/v1/all-rss-feed.xml> | National cyber news & guidance | **OGL v3.0** | Advisories, guidance notes and incident reports from the UK’s National Cyber Security Centre. |
+| 4 | **SANS Internet Storm Center Diaries** | <https://isc.sans.edu/rssfeed_full.xml> | Daily threat analysis | **CC BY-NC-SA 3.0 US** | Community-run diary posts analysing emerging attack trends, malware and exploits. Requires non-commercial use and attribution. |
+| 5 | **CERT-EU Security Advisories** | <https://cert.europa.eu/publications/threat-intelligence-rss> | EU-focused advisories & vulnerabilities | **CC BY 4.0** | Bulletins for EU institutions and agencies on newly disclosed vulnerabilities and threats. |
 
-## Major Paid Threat Intelligence Feeds (Overview)
+All five feeds are enabled in `Cargo.toml` and ingested hourly by default (or at the feed’s own `<ttl>` cadence if provided).
 
-In addition to the free sources above, there are several high-quality commercial threat intelligence feeds available. These typically require a subscription and are used by organisations needing advanced or niche intelligence. Pricing for paid feeds varies widely – annual subscriptions can range from a few thousand to over $100,000 USD per year​ (tens of thousands of pounds sterling), depending on the depth of intelligence and services included. Below are some of the leading paid intel feed providers, along with their focus and value:
+---
 
-- **Recorded Future – A comprehensive threat intelligence platform aggregating open source, dark web, technical, and geopolitical data in real time.** 
+## 🚧 Feeds removed from the public demo
 
-    Focus: Broad threat intelligence (indicators, threat actor tracking, vulnerabilities) with extensive context and analytics. Value: Known for its large collection and machine learning analytics, Recorded Future helps organisations proactively identify emerging threats. However, it is premium-priced (often in the high tens of thousands per annum) commensurate with its depth and tool integrations​
+| Reason | Examples |
+|--------|----------|
+| Proprietary **“all rights reserved”** content | Krebs on Security, Dark Reading, BleepingComputer, The Hacker News, Microsoft MSRC, Cisco Talos, etc. |
+| Licenced only for **personal use** via RSS | Exploit-DB, Threatpost, Malwarebytes Labs |
+| Unclear or mixed user-generated copyright | Reddit /r/netsec |
 
-- **CrowdStrike Falcon Intelligence – Threat feed and reports from CrowdStrike’s renowned team (behind the Falcon platform).** 
+These feeds remain in the codebase (parsers & unit tests) but are commented out in `Cargo.toml`.  Organisations may enable them privately at their own risk.
 
-    Focus: Nation-state APT groups, cyber-criminal campaigns, malware threat indicators, and actor profiles. Type: Paid (vendor). Value: Provides highly actionable intelligence tied to CrowdStrike’s endpoint products – including adversary tactics, techniques, and procedures (TTPs) – enabling organisations to bolster threat hunting and incident response. Priced for enterprise, often part of a larger EDR bundle.
+---
 
-- **Mandiant Threat Intelligence (FireEye) – Intel service from Mandiant (Google Cloud).** 
+## ➕ Optional open feeds (commented-out examples)
 
-    Focus: In-depth reports on advanced threat actors, major breaches, zero-day vulnerabilities, and strategic intelligence. Value: Mandiant’s team is usually first to investigate major APT incidents; subscribers get early access to detailed reports and IOCs from real incident responses. High annual cost, but valued for the quality of analysis and front-line breach insights.
+If you need more coverage without licence headaches, uncomment and test any of the following:
 
-- **Flashpoint – Specialist in dark web and threat actor intelligence.** 
+| Feed | Link | Licence | What you gain |
+|------|------|---------|---------------|
+| **CISA Known Exploited Vulnerabilities (KEV)** | <https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.xml> | Public Domain | Live list of CVEs confirmed to be exploited in the wild. |
+| **Australian ACSC Alerts** | <https://www.cyber.gov.au/alerts/rss.xml> | CC BY 4.0 AU | Southern-hemisphere advisories and incident notes. |
+| **CERT-NZ Advisories** | <https://www.cert.govt.nz/it-specialists/rss-advisories/> | CC BY 4.0 NZ | Additional vulnerability and incident context. |
+| **NVD CVE JSON 2.0** | <https://services.nvd.nist.gov/rest/json/cves/2.0?recent=true> | Public Domain | Machine-readable CVE data for enrichment (bulk API). |
+| **MITRE ATT&CK Changelog** | <https://github.com/mitre/cti/releases.atom> | Royalty-free | Detects new/renamed techniques for mapping enrichment. |
 
-    Focus: Closed forums, criminal marketplaces, threat actor communications (including geopolitical risks and fraud). Value: Delivers intelligence that isn’t available on open channels, helping organisations detect criminal targeting or data leaks. Often used by financial and government sectors; subscriptions are premium, reflecting the specialised dark web monitoring capabilities.
+---
 
-- **Intel 471 – Cybercrime underground focused feed.** 
-    
-    Focus: Malware-as-a-service operations, ransomware gangs, criminal forums, and botnet intel. Value: Provides vetted intelligence on threat actor activities and technical IOCs from the cyber underground. Typically paid by large enterprises and MSSPs to preempt cybercrime threats. Cost is significant and usually tailored to the scope of coverage needed.
+## 👣 Attribution requirements
 
-- **Kaspersky Threat Intelligence Services – (Paid feeds by Kaspersky Lab).** 
-    
-    Focus: APT reports, crimeware campaigns, threat data feeds (malicious URLs, file hashes, etc.), and underground forum monitoring. Value: Leverages Kaspersky’s global research (including regions like Russia/CIS) for exclusive insights. Offers data feeds that integrate into SIEMs. Paid tiers vary; comprehensive packages can be costly, but provide very granular IOC data and reports.
+* **CISA & other US-Gov feeds:** no legal attribution required, but a courtesy line such as `© CISA (US Government, public domain)` is good practice.
+* **UK NCSC (OGL v3.0):** must include `© Crown copyright 20XX, NCSC. Contains public-sector information licensed under the Open Government Licence v3.0.`
+* **SANS ISC (CC BY-NC-SA):** non-commercial use only; include `© SANS Internet Storm Center – CC BY-NC-SA 3.0 US` with a link back.
+* **CERT-EU (CC BY 4.0):** include `© CERT-EU – CC BY 4.0` + link.
 
-Other notable paid feeds include IBM X-Force Premium, BT Security Threat Intelligence, SophosLabs Intelix, and feeds from platform providers like Anomali or ThreatConnect. These services often bundle proactive alerts, data APIs, analyst support, and tailored reporting. Organizations considering paid feeds should weigh the cost against the value of earlier warnings and richer context (e.g. exclusive indicators, detailed actor dossiers, and predictive analysis). High-quality paid feeds can significantly enhance an OSINT ingestion system by providing curated, context-rich intelligence not readily available from free sources, but they are usually only justified for organisations with mature security operations and sufficient budget.
+The dashboard displays this attribution in the article card footer and again in the `/sources` page.
 
+---
 
-# Citations
+## 🛠 Adding a new feed
 
-1. **GitHub - thehappydinoa/awesome-threat-intel-rss**
- 
-   - **Description**: A curated list of Awesome Threat Intelligence blogs.
-   - **Details**:
-     - Provide timely information about current security issues, vulnerabilities, and exploits.
-     - **Web**: https://us-cert.cisa.gov/ncas/alerts
-     - **Feed**: https://us-cert.cisa.gov/ncas/alerts.xml
+1. **Check the licence** – look for CC, OGL, US-Gov PD, or equivalent.  When in doubt, e-mail the publisher.
+2. **Update `Cargo.toml`** – add `licence = "…"` and appropriate tags.
+3. **Limit excerpt** – the public cache stores **≤ 100 characters** of AI-generated summary and the original headline only.
+4. **Run `cargo test`** – ensure the parser and licence checker pass.
+5. **Deploy** – watch logs for `LicenceWarning` on first ingest.
 
-2. **Getting the most from the SANS Internet Storm Center | Barracuda Networks Blog**
+---
 
-   - **Description**: Threat data analysis. The ISC is staffed by about 40 volunteer “handlers” who analyse incoming threat data using an ever-evolving set of tools. They post daily “diaries” highlighting new threats, emerging trends, and security industry developments, along with daily summary podcasts.
+## Citations & Licence sources
 
-3. **Awesome Threat Intel RSS** (via GitHub)
+1. **CISA Terms of Use (public domain)** – <https://www.cisa.gov/about/tou>  
+2. **UK Open Government Licence v3.0** – <https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/>  
+3. **SANS ISC Licence Notice** – Diary page footer, e.g. <https://isc.sans.edu/>  
+4. **CERT-EU RSS page** – <https://cert.europa.eu/about>  
 
-   - **Feeds**:
-     - **Krebs on Security**
-       - **Description**: Brian Krebs is a household name in information security, and his blog is among the most well known and respected in the space. A daily blog dedicated to investigative stories on cybercrime and computer security.
-       - **Web**: https://krebsonsecurity.com/
-       - **Feed**: http://krebsonsecurity.com/feed/
-       - **Subscribe**: https://app.obstracts.com/
-     - **Lohrmann on Cybersecurity**
+_All links accessed 29 May 2025._
 
-4. **Top 15 Data Breach RSS Feeds**
+---
 
-   - **Description**: Blog posts on data breaches in various industries such as business, education, and finance, as well as articles on data breach regulations and legislation. Combines news aggregation with investigative reporting and opinion.
-   - **More**: Twitter Followers 10K
-   - **Email**: anuj@feedspot.com
-
-5. **Threatpost** (via GitHub Awesome list)
-
-   - **Description**: An independent news site, leading source of information about IT and business security for hundreds of thousands of professionals.
-   - **Frequency**: 27 posts per week
-   - **Web**: https://threatpost.com/
-   - **Feed**: https://threatpost.com/feed/
-
-6. **Only 30? Why not 108? You're welcome** (Medium)
-
-   - **Feed Links**: 
-     - http://www.kb.cert.org/vulfeed/
-     - https://cyware.com/rss-feed/
-     - https://dragos.com/feed/
-
-7. **/r/netsec** (via GitHub Awesome list)
-
-   - **Description**: Network security sub-Reddit.
-   - **Feed**: https://www.reddit.com/r/netsec/.rss
-
-8. **What are Threat Intelligence Feeds?**
-
-   - **Description**: Paid feeds often require an annual subscription ranging from a few thousand dollars to over $100,000 per year. Organisations should align their choice of threat intelligence feeds with their cybersecurity budget.
-
-## All Sources
-
-- github (14)
-- reddit (3)
-- rss.feedspot (5)
-- ncsc.gov (2)
-- news.ycombinator
-- nvd.nist (2)
-- feeder (2)
-- packetstorm
-- krebsonsecurity
-- feeds.feedburner
-- cisa
-- aboutdfir
-- cert.europa
-- en.wikipedia
-- blog.barracuda
+Happy hacking!  If you spot any licence drift, open an issue or e-mail **legal@tigerblue.app**.


### PR DESCRIPTION
* Removed 15 proprietary/personal-use feeds from Cargo.toml
* Added explicit  field to each remaining feed
* Updated README:
  * Replaced 20-feed matrix with 5-feed green list
  * Added attribution rules, optional open feeds, and licence citations
* Embedded licence-compliance notes and cache/excerpt limits